### PR TITLE
Add Containerfile.art for ART builds

### DIFF
--- a/Containerfile.art
+++ b/Containerfile.art
@@ -1,0 +1,45 @@
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
+
+ARG SOURCE_DIR="/go/src/github.com/openshift/spiffe-spire-controller-manager"
+WORKDIR ${SOURCE_DIR}
+
+COPY . .
+COPY LICENSE /licenses/.
+
+ENV CGO_ENABLED=1
+ENV GO_BUILD_TAGS=strictfipsruntime,openssl
+ENV GOEXPERIMENT=strictfipsruntime
+ENV GOFLAGS=""
+
+RUN go build -o bin/spire-controller-manager -ldflags "-w -s" -tags ${GO_BUILD_TAGS} cmd/main.go
+
+FROM registry.redhat.io/ubi9/ubi-minimal:latest@sha256:ae09ecc3d754bc1726cbda3e2599cc7839e09fe1cc547ce173cf669b645be3cc
+
+ARG RELEASE_VERSION
+ARG COMMIT_SHA
+ARG SOURCE_URL
+ARG SOURCE_DIR="/go/src/github.com/openshift/spiffe-spire-controller-manager"
+
+COPY --from=builder ${SOURCE_DIR}/bin/spire-controller-manager /spire-controller-manager
+COPY --from=builder /licenses /licenses
+
+USER 65534:65534
+
+LABEL name="zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9" \
+      version="${RELEASE_VERSION}" \
+      release="${RELEASE_VERSION}" \
+      summary="SPIFFE-SPIRE Controller Manager for Kubernetes" \
+      description="Controller for managing SPIFFE and SPIRE identities in OpenShift clusters." \
+      maintainer="Red Hat, Inc." \
+      vendor="Red Hat, Inc." \
+      com.redhat.component="spiffe-spire-controller-manager-container" \
+      io.k8s.display-name="SPIFFE-SPIRE Controller Manager" \
+      io.k8s.description="Kubernetes controller for SPIFFE/SPIRE identity management." \
+      io.openshift.tags="spiffe,spire,controller,security,identity" \
+      io.openshift.expose-services="" \
+      io.openshift.build.commit.id="${COMMIT_SHA}" \
+      io.openshift.build.source-location="${SOURCE_URL}" \
+      io.openshift.build.commit.url="${SOURCE_URL}/commit/${COMMIT_SHA}" \
+      cpe="cpe:/a:redhat:zero_trust_workload_identity_manager:1.1::el9"
+
+ENTRYPOINT ["/spire-controller-manager"]


### PR DESCRIPTION
## Problem Statement

ART needs to build spiffe-spire-controller-manager images through its Konflux-based layered products pipeline. ART builds require a dedicated Containerfile.art with ART's builder images, base images, and LABEL conventions.

## Related Issue

Part of [ART-14816](https://redhat.atlassian.net/browse/ART-14816) (Onboard OAP operators to ART) and [ART-14825](https://redhat.atlassian.net/browse/ART-14825) (Onboard Zero Trust to ocp-build-data).

## Proposed Changes

Add Containerfile.art adapted from zero-trust-workload-identity-manager-release release-1.1 for ART build pipeline (COPY . . instead of submodule, ART builder images and labels).